### PR TITLE
[FIX] 로딩 스피너 오류 수정 

### DIFF
--- a/frontend/src/css/global.scss
+++ b/frontend/src/css/global.scss
@@ -144,6 +144,16 @@ a {
   text-decoration: none;
 }
 
+.map-loading-overlay {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(255, 255, 255, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
 .loading-spinner-container {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/Find.jsx
+++ b/frontend/src/pages/Find.jsx
@@ -61,12 +61,18 @@ export default function Find() {
   return (
     <div className="page-layout">
       <div className="page-section">
-        {isLoading ? (
-          <LoadingSpinner message="🌱 단독 스팟을 불러오는 중이에요..." />
-        ) : (
-          <Suspense fallback={<div>지도를 불러오는 중...</div>}>
-            <LazyMap searchResults={searchResults} showLocationMarker={false} />
-          </Suspense>
+        <Suspense fallback={<div>지도를 불러오는 중...</div>}>
+          <LazyMap searchResults={searchResults} showLocationMarker={false} />
+        </Suspense>
+        {isLoading && (
+          <div className="map-loading-overlay">
+            <div className="loading-spinner-container">
+              <div className="loading-spinner" />
+              <div className="loading-text">
+                🌱 단독 스팟을 불러오는 중이에요...
+              </div>
+            </div>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
### 작업 내용
- isLoading일 때 lazymap이 아예 돔에서 제거되고 로딩이 끝난후 다시 나타나 처음부터 마운트되어 초기값으로 돌아감 