### PR TITLE
[BE] 멀티스레드 환경 LazyInitializationException 해결 

### DIFF
--- a/backend/src/main/java/com/jeongmin/backend/facade/DecorFacade.java
+++ b/backend/src/main/java/com/jeongmin/backend/facade/DecorFacade.java
@@ -65,10 +65,15 @@ public class DecorFacade {
     }
 
 
+    public DecorResponse createNewDecorWithoutLock(DecorCreateRequest request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        return decorService.createNewDecorTransactional(request, userId);
+    }
+
     public DecorResponse createNewDecor(DecorCreateRequest request) {
-        User user = userService.getCurrentUser();
+        Long userId = SecurityUtil.getCurrentUserId();
         List<String> lockKeys = lockKeyGenerator.generate(request);
-        return lockManager.executeWithLock(lockKeys, () -> decorService.createNewDecorTransactional(request, user));
+        return lockManager.executeWithLock(lockKeys, () -> decorService.createNewDecorTransactional(request, userId));
     }
 
 

--- a/backend/src/main/java/com/jeongmin/backend/service/DecorService.java
+++ b/backend/src/main/java/com/jeongmin/backend/service/DecorService.java
@@ -9,6 +9,7 @@ import com.jeongmin.backend.entity.User;
 import com.jeongmin.backend.exception.ErrorCode;
 import com.jeongmin.backend.exception.RestApiException;
 import com.jeongmin.backend.repository.DecorRepository;
+import com.jeongmin.backend.repository.UserRepository;
 import com.jeongmin.backend.utils.GeoUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,7 @@ import java.util.List;
 public class DecorService {
 
     private final DecorRepository decorRepository;
+    private final UserRepository userRepository;
 
     public void delete(Decor decor) {
         decorRepository.delete(decor);
@@ -40,10 +42,12 @@ public class DecorService {
     }
 
     @Transactional
-    public DecorResponse createNewDecorTransactional(DecorCreateRequest request, User user) {
+    public DecorResponse createNewDecorTransactional(DecorCreateRequest request, Long userId) {
         if (checkDecorExistsNearby(request.lat(), request.lng(), request.type())) {
             throw new RestApiException(ErrorCode.DUPLICATE_DECOR);
         }
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
         Decor decor = createDecor(request, user);
         return DecorResponse.from(decor);
     }


### PR DESCRIPTION
## Summary

멀티스레드 환경에서 발생하던 LazyInitializationException을 해결하였습니다.

## 주요 변경사항

###  LazyInitializationException 해결 (DecorService, DecorFacade)

기존에 `DecorFacade`에서 조회한 `User` 객체를 람다로 캡처해 다른 스레드에 전달하는 방식에서,
Hibernate Session이 스레드에 묶여 있어 다른 스레드의 Session과 불일치가 발생했습니다.

- `createNewDecorTransactional(request, User)` → `createNewDecorTransactional(request, Long userId)`
- `DecorService` 트랜잭션 내부에서 `userId`로 `User`를 직접 재조회해 현재 Session 보장
- `DecorFacade`에서 `SecurityUtil.getCurrentUserId()`로 `userId`만 추출해 전달
- `UserRepository` 의존성 추가


